### PR TITLE
Upates WordPress image to use PHP 7.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
    wordpress:
      depends_on:
        - db
-     image: wordpress:latest
+     image: wordpress:5-php7.1
      ports:
        - "8000:80"
      restart: always


### PR DESCRIPTION
This sets the Docker container for the WordPress application to match the PHP version we are using in production currently.