### PR TITLE
Add an initial setup step

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,5 +49,8 @@
         "wpackagist-plugin/wp-security-audit-log": "3.5.2.1",
         "wpackagist-plugin/wp-sentry-integration": "^3.0",
         "wpackagist-plugin/wp-table-reloaded": "^1.9"
+    },
+    "scripts": {
+        "setup": "./post-setup.sh"
     }
 }

--- a/post-setup.sh
+++ b/post-setup.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Install locally-developed themes
+git clone https://github.com/mitlibraries/mitlibraries-parent ./wp-content/themes/libraries/
+cd wp-content/themes/libraries/
+npm install; grunt
+cd ../../../
+
+git clone https://github.com/mitlibraries/mitlibraries-child ./wp-content/themes/libraries-child-new/
+cd wp-content/themes/libraries-child-new/
+npm install; grunt
+cd ../../../
+
+git clone https://github.com/mitlibraries/mitlibraries-news ./wp-content/themes/mit-libraries-news/
+cd wp-content/themes/mit-libraries-news/
+npm install; grunt
+cd ../../../
+
+git clone https://github.com/mitlibraries/music-oral-history ./wp-content/themes/music-oral-history/
+cd wp-content/themes/music-oral-history/
+npm install; grunt
+cd ../../../
+
+git clone https://github.com/mitlibraries/mitlib-courtyard ./wp-content/themes/mitlib-courtyard/
+cd wp-content/themes/mitlib-courtyard/
+npm install; grunt
+cd ../../../
+
+git clone https://github.com/mitlibraries/mitlib-courtyard-blog ./wp-content/themes/mitlib-courtyard-blog/
+cd wp-content/themes/mitlib-courtyard-blog/
+npm install; grunt
+cd ../../../
+
+# Install locally-developed plugins
+git clone https://github.com/MITLibraries/wp-multisearch-widget ./wp-content/plugins/wp-multisearch-widget/

--- a/post-setup.sh
+++ b/post-setup.sh
@@ -32,4 +32,18 @@ npm install; grunt
 cd ../../../
 
 # Install locally-developed plugins
-git clone https://github.com/MITLibraries/wp-multisearch-widget ./wp-content/plugins/wp-multisearch-widget/
+cd wp-content/plugins
+git clone https://github.com/MITLibraries/Custom-Child-Theme-Post-Types
+git clone https://github.com/MITLibraries/mitlib-analytics
+git clone https://github.com/MITLibraries/mitlib-cf7-elements
+git clone https://github.com/MITLibraries/mitlib-plugin-canary
+git clone https://github.com/MITLibraries/mitlib-private-debug-log
+git clone https://github.com/MITLibraries/mitlib-pull-hours
+git clone https://github.com/MITLibraries/pull-mit-events
+git clone https://github.com/MITLibraries/wp-home-page-news
+git clone https://github.com/MITLibraries/wp-multisearch-widget
+git clone https://github.com/MITLibraries/wp-pending-posts
+git clone https://github.com/MITLibraries/wp-plugin-template
+cd ../../
+
+# The next steps would be to build out the WordPress network itself...

--- a/readme.md
+++ b/readme.md
@@ -1,33 +1,30 @@
 # Local Dev for MIT Wordpress
 
-## clone this repo
+## Clone this repo
 
 - git clone
 - cd into it
 - proceed to setup wordpress
 
-## Setup wordpress
+## Setup WordPress
 
-- docker-compose up
-- http://localhost:8000/wp-admin/
-- don't forget the password you make (when you do, you can delete the docker DB
-  filesystem and start over)
+- `docker-compose up`
+- Visit http://localhost:8000/ in your browser of choice to complete the Five Minute Setup. When you see the Wordpress Admin interface, you are done with this step.
+- Do not forget the password you make here! (When you do, you can delete the docker DB filesystem and start over)
 
-## checkout our local themes and plugins as git repos
+## Check out locally-developed code
 
-- docker-compose down (if it's running)
-- git clone git@github.com:MITLibraries/MITlibraries-parent.git wp-content/themes/MITlibraries-parent
-- do stuff the themes / plugins need, ex parent needs `npm install; grunt`
-- (repeat for whatever you need)
-- docker-compose up
-- wp-admin and activate themes / plugins
-- wp-admin set a default page
+- `composer setup` (or just run `post-setup.sh`) from the repository root. This will clone all projects, as well as install and run the build step for our themes.
+- Visit http://localhost:8000/wp-admin/themes.php to see the installed (and built) themes.
+- Enable the Parent theme using the link provided.
+- Load the sample page at http://localhost:8000/?page_id=2
+- **Please note** at this point, the homepage at http://localhost:8000/ will be a blank white screen. This is a known issue.
 
-## composer to grab plugins
+## Install community plugins and themes via Composer
 
-- composer install
-- activate whatever you need (I have no idea!) in the wp-admin
+- `composer install`
+- Activate whatever you need (I have no idea!) in the wp-admin.
 
-## content
+## Load site content
 
 - tbd


### PR DESCRIPTION
This adds a bash script that can be run as part of the initial setup of this docker image. It can either be invoked by Composer via `composer setup` or directly.

The script will clone each locally-developed theme, install the npm tooling, and run the build step.

This does not do anything to populate the site content, nor build out the expected WordPress network, nor enable the relevant plugins. All of those steps should be possible if the WP CLI is available.

**To replicate**
I've updated the project readme with the instructions I think are needed; please check those?