### PR TITLE
Adds support for WordPress CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 wp-content
+wp-app
 vendor

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+SHELL=/bin/bash
+
+help: ## Print this message
+	@awk 'BEGIN { FS = ":.*##"; print "Usage:  make <target>\n\nTargets:" } \
+/^[-_[:alpha:]]+:.?*##/ { printf "  %-15s%s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+install: ## Install dependencies
+	composer install
+
+setup: ## Check out copies of all of our themes and plugins we work on
+	./post-setup.sh
+
+plugins: ## List status of plugins
+	docker-compose run --rm wpcli plugin list
+
+themes: ## List status of themes
+	docker-compose run --rm wpcli theme list
+
+up: ## Starts WordPress and MySQL
+	docker-compose up -d
+
+down: ## Stops Wordpress and MySQL
+	docker-compose down
+
+drop: ## Drops database. Recreate with `up` then `admin`
+	docker-compose down -v
+
+admin: up ## Launches admin site in default browser
+	open http://localhost:8000/wp-admin

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,13 @@
         "wpackagist-plugin/wp-sentry-integration": "^3.0",
         "wpackagist-plugin/wp-table-reloaded": "^1.9"
     },
+    "extra": {
+        "wordpress-install-dir": "wp-app",
+        "installer-paths": {
+            "wp-app/wp-content/plugins/{$name}/": ["type:wordpress-plugin"],
+            "wp-app/wp-content/themes/{$name}/": ["type:wordpress-theme"]
+        }
+    },
     "scripts": {
         "setup": "./post-setup.sh"
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,38 @@
 version: '3.3'
 
 services:
-   db:
-     image: mysql:5.7
-     volumes:
-       - db_data:/var/lib/mysql
-     restart: always
-     environment:
-       MYSQL_ROOT_PASSWORD: somewordpress
-       MYSQL_DATABASE: wordpress
-       MYSQL_USER: wordpress
-       MYSQL_PASSWORD: wordpress
+  db:
+    image: mysql:5.7
+    volumes:
+      - db_data:/var/lib/mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: somewordpress
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
 
-   wordpress:
-     depends_on:
-       - db
-     image: wordpress:5-php7.1
-     ports:
-       - "8000:80"
-     restart: always
-     environment:
-       WORDPRESS_DB_HOST: db:3306
-       WORDPRESS_DB_USER: wordpress
-       WORDPRESS_DB_PASSWORD: wordpress
-       WORDPRESS_DB_NAME: wordpress
-     volumes:
-       - ./wp-content:/var/www/html/wp-content
+  wordpress:
+    depends_on:
+      - db
+    image: wordpress:5-php7.1
+    ports:
+      - "8000:80"
+    restart: always
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - ./wp-app:/var/www/html
+
+  wpcli:
+    image: wordpress:cli-php7.1
+    volumes:
+      - ./wp-app:/var/www/html
+    depends_on:
+      - db
+      - wordpress
 volumes:
     db_data: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/post-setup.sh
+++ b/post-setup.sh
@@ -1,38 +1,46 @@
 #!/usr/bin/env bash
 
 # Install locally-developed themes
-git clone https://github.com/mitlibraries/mitlibraries-parent ./wp-content/themes/libraries/
-cd wp-content/themes/libraries/
-npm install; grunt
-cd ../../../
+base_dir=$(pwd)
 
-git clone https://github.com/mitlibraries/mitlibraries-child ./wp-content/themes/libraries-child-new/
-cd wp-content/themes/libraries-child-new/
+target_dir=./wp-app/wp-content/themes/libraries/
+git clone https://github.com/mitlibraries/mitlibraries-parent $target_dir
+cd $target_dir
 npm install; grunt
-cd ../../../
+cd $base_dir
 
-git clone https://github.com/mitlibraries/mitlibraries-news ./wp-content/themes/mit-libraries-news/
-cd wp-content/themes/mit-libraries-news/
+target_dir=./wp-app/wp-content/themes/libraries-child-new/
+git clone https://github.com/mitlibraries/mitlibraries-child $target_dir
+cd $target_dir
 npm install; grunt
-cd ../../../
+cd $base_dir
 
-git clone https://github.com/mitlibraries/music-oral-history ./wp-content/themes/music-oral-history/
-cd wp-content/themes/music-oral-history/
+target_dir=./wp-app/wp-content/themes/mit-libraries-news/
+git clone https://github.com/mitlibraries/mitlibraries-news $target_dir
+cd $target_dir
 npm install; grunt
-cd ../../../
+cd $base_dir
 
-git clone https://github.com/mitlibraries/mitlib-courtyard ./wp-content/themes/mitlib-courtyard/
-cd wp-content/themes/mitlib-courtyard/
+target_dir=./wp-app/wp-content/themes/music-oral-history/
+git clone https://github.com/mitlibraries/music-oral-history $target_dir
+cd $target_dir
 npm install; grunt
-cd ../../../
+cd $base_dir
 
-git clone https://github.com/mitlibraries/mitlib-courtyard-blog ./wp-content/themes/mitlib-courtyard-blog/
-cd wp-content/themes/mitlib-courtyard-blog/
+target_dir=./wp-app/wp-content/themes/mitlib-courtyard/
+git clone https://github.com/mitlibraries/mitlib-courtyard $target_dir
+cd $target_dir
 npm install; grunt
-cd ../../../
+cd $base_dir
+
+target_dir=./wp-app/wp-content/themes/mitlib-courtyard-blog/
+git clone https://github.com/mitlibraries/mitlib-courtyard-blog $target_dir
+cd $target_dir
+npm install; grunt
+cd $base_dir
 
 # Install locally-developed plugins
-cd wp-content/plugins
+cd ./wp-app/wp-content/plugins
 git clone https://github.com/MITLibraries/Custom-Child-Theme-Post-Types
 git clone https://github.com/MITLibraries/mitlib-analytics
 git clone https://github.com/MITLibraries/mitlib-cf7-elements
@@ -44,6 +52,6 @@ git clone https://github.com/MITLibraries/wp-home-page-news
 git clone https://github.com/MITLibraries/wp-multisearch-widget
 git clone https://github.com/MITLibraries/wp-pending-posts
 git clone https://github.com/MITLibraries/wp-plugin-template
-cd ../../
+cd $base_dir
 
 # The next steps would be to build out the WordPress network itself...

--- a/readme.md
+++ b/readme.md
@@ -8,9 +8,9 @@
 
 ## Setup WordPress
 
-- `docker-compose up`
+- `docker-compose up` or `make admin`
 - Visit http://localhost:8000/ in your browser of choice to complete the Five Minute Setup. When you see the Wordpress Admin interface, you are done with this step.
-- Do not forget the password you make here! (When you do, you can delete the docker DB filesystem and start over)
+- Do not forget the password you make here! (When you do, you can delete the docker DB filesystem and start over: `docker-compose down -v` should do that)
 
 ## Check out locally-developed code
 
@@ -22,9 +22,43 @@
 
 ## Install community plugins and themes via Composer
 
-- `composer install`
+- `composer install` or `make install`
 - Activate whatever you need (I have no idea!) in the wp-admin.
 
 ## Load site content
 
 - tbd
+
+## Reset your dev environment entirely
+
+Remove the docker volumes:
+`docker-compose down -v` or `make drop`
+
+Delete the directory (recursively) for your checkout of this repository. This
+will delete all of your checked out copies of our themes and plugins! If you
+have work you have not saved, commit and push to branches on github.
+
+Start back at the top of this readme.
+
+## WordPress CLI
+
+You can use the WordPress CLI. The syntax is:
+
+```bash
+docker-compose run --rm wpcli theme activate libraries
+```
+
+## Make commands
+
+There are several useful `make` commands available to assist in local
+development.
+
+You can see the list and a brief description of what they do by typing:
+
+```bash
+make
+```
+
+These are entirely syntactic sugar and everything can be done manually if you
+prefer. The commands are defined in `Makefile` and additional commands should
+be added as we determine what makes the most sense for our local dev.


### PR DESCRIPTION
**IMPORTANT NOTE: this moves the linked directory up a level in the docker container from `wp-content` to `html`, which is linked as `wp-app` locally. Because of this, it's best to probably start over with your local setup to get it to all synch up correctly.** This change was necessary to allow the WordPress CLI to work.

Most of the changes to `docker-compose.yml` are whitespace. The important bits are the `wpcli` stanza.

This adds support for arbitrary WordPress CLI commands in our Docker
environment.

It also adds some `make` commands to simplify some common development
tasks in this Docker environment.