### PR TITLE
Upgrade PHP to 7.2.x

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   wordpress:
     depends_on:
       - db
-    image: wordpress:5-php7.1
+    image: wordpress:5-php7.2
     ports:
       - "80:80"
     restart: always
@@ -28,7 +28,7 @@ services:
       - ./wp-app:/var/www/html
 
   wpcli:
-    image: wordpress:cli-php7.1
+    image: wordpress:cli-php7.2
     volumes:
       - ./wp-app:/var/www/html
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   wordpress:
     depends_on:
       - db
-    image: wordpress:5-php7.2
+    image: wordpress:5.4.2-php7.2
     ports:
       - "80:80"
     restart: always


### PR DESCRIPTION
Now that our production site is running PHP 7.2, this seems a good time to update this project to match.

## To evaluate

You should only need to run `docker-compose up` on this branch, and the new images should be downloaded. The best way to verify that all has worked is to check the Site Health report at http://localhost/wp-admin/site-health.php - you should see a notice that your site is running PHP 7.2.32 (with a gentle request that you update, rather than a strong warning that you're running something in the 7.1.x family)

## Please note

While the image we're using here indicates WordPress 5.4.2, the image actually doesn't mandate that this is used. If you have already installed WordPress under an earlier image, you will need to follow WordPress' built-in update process for upgrading the WordPress core.

(Whether we want to leave this up to local devs to do, or specify it in code via Composer, is a conversation that I'm open to having)
